### PR TITLE
Make `Expr` untyped

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "purescript-formal",
   "scripts": {
-    "build": "pulp build --to dist/main.js -- --censor-lib --stash --strict",
+    "build": "npm run compile && pulp build --to dist/main.js",
+    "compile": "pulp build -- --censor-lib --stash --strict",
     "test": "pulp test"
   },
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
   "name": "purescript-formal",
   "scripts": {
-    "build": "pulp build --to dist/main.js",
+    "build": "pulp build --to dist/main.js -- --censor-lib --stash --strict",
     "test": "pulp test"
   },
   "license": "ISC",
   "devDependencies": {
     "bower": "^1.8.8",
     "pulp": "^12.3.1",
-    "purescript": "^0.12.2"
+    "purescript": "^0.12.2",
+    "purescript-psa": "^0.7.3"
   }
 }

--- a/src/Data/Expr.purs
+++ b/src/Data/Expr.purs
@@ -2,6 +2,7 @@ module Lynx.Data.Expr where
 
 import Prelude
 
+import Data.Argonaut (class DecodeJson, class EncodeJson, Json, decodeJson, encodeJson, jsonEmptyObject, (.:), (:=), (~>))
 import Data.Either (Either(..))
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
@@ -19,6 +20,17 @@ derive instance genericExprType :: Generic ExprType _
 instance showExprType :: Show ExprType where
   show = genericShow
 
+instance encodeJsonExprType :: EncodeJson ExprType where
+  encodeJson = case _ of
+    Boolean x -> encodeJson x
+    Int x -> encodeJson x
+    String x -> encodeJson x
+
+reflectType :: ExprType -> String
+reflectType (Boolean _) = "Boolean"
+reflectType (Int _) = "Int"
+reflectType (String _) = "String"
+
 data Expr
   = Val ExprType
   | If Expr Expr Expr
@@ -30,11 +42,72 @@ derive instance genericExpr :: Generic Expr _
 instance showExpr :: Show Expr where
   show x = genericShow x
 
+instance encodeJsonExpr :: EncodeJson Expr where
+  encodeJson = encodeJson <<< toExprA
+
+instance decodeJsonExpr :: DecodeJson Expr where
+  decodeJson json = do
+    x' <- decodeJson json
+    x' .: "op" >>= case _ of
+      "Val" -> x' .: "out" >>= case _ of
+        "Boolean" -> x' .: "param" >>= pure <<< boolean_
+        "Int" -> x' .: "param" >>= pure <<< int_
+        "String" -> x' .: "param" >>= pure <<< string_
+        out -> Left $ out <> " not implemented"
+      "If" -> x' .: "params" >>= case _ of
+        [x, y, z] -> pure (if_ x y z)
+        _ -> Left "Expected 3 params"
+      "Equal" -> x' .: "params" >>= case _ of
+        [x, y] -> pure (equal_ x y)
+        _ -> Left "Expected 2 params"
+      "Lookup" -> x' .: "param" >>= pure <<< lookup_
+      op -> Left $ op <> " invalid op"
+
+data ExprA
+  = ValA ExprType
+  | IfA ExprA ExprA ExprA String String
+  | EqualA ExprA ExprA String String
+  | LookupA Key String
+
+instance encodeJsonExprA :: EncodeJson ExprA where
+  encodeJson =
+    case _ of
+      ValA x -> "param" := x ~> encodeHelper "Val" "Void" (reflectType x)
+      IfA x y z i o ->
+        "params" := [ x, y, z ] ~> encodeHelper "If" i o
+      EqualA x y i o ->
+        "params" := [ x, y ] ~> encodeHelper "Equal" i o
+      LookupA x o -> "param" := x ~> encodeHelper "Lookup" "Void" o
+
+toExprA :: Expr -> ExprA
+toExprA = case _ of
+  Val x -> ValA x
+  If x y z -> IfA (toExprA x) (toExprA y) (toExprA z) (reflectIn x) (reflectOut y)
+  Equal x y -> EqualA (toExprA x) (toExprA y) (reflectIn x) (reflectOut x)
+  Lookup x -> LookupA x "???"
+  where
+  reflectIn :: Expr -> String
+  reflectIn = case _ of
+    Val _ -> "Void"
+    If x _ _ -> reflectIn x
+    Equal x _ -> reflectIn x
+    Lookup _ -> "Void"
+  reflectOut :: Expr -> String
+  reflectOut = case _ of
+    Val x -> reflectType x
+    If _ x _ -> reflectOut x
+    Equal _ _ -> "Boolean"
+    Lookup _ -> "???"
+
+encodeHelper :: String -> String -> String -> Json
+encodeHelper op i o =
+  "op" := op ~> "in" := i ~> "out" := o ~> jsonEmptyObject
+
 data EvalError
   = MissingKey Key
   | IfCondition ExprType
   | EqualMismatch { left :: ExprType, right :: ExprType }
-  
+
 evalExpr :: (Key -> Maybe ExprType) -> Expr -> Either EvalError ExprType
 evalExpr get = case _ of
   Val x -> pure x

--- a/src/Data/Expr.purs
+++ b/src/Data/Expr.purs
@@ -2,261 +2,70 @@ module Lynx.Data.Expr where
 
 import Prelude
 
-import Data.Argonaut (class DecodeJson, class EncodeJson, Json, decodeJson, encodeJson, jsonEmptyObject, (.:), (:=), (~>))
 import Data.Either (Either(..))
-import Data.Leibniz (type (~), coerceSymm)
-import Type.Prelude (Proxy(..))
+import Data.Generic.Rep (class Generic)
+import Data.Generic.Rep.Show (genericShow)
+import Data.Maybe (Maybe, maybe)
+
+type Key = String
 
 data ExprType
   = Boolean Boolean
   | Int Int
   | String String
 
-reflectType :: ExprType -> String
-reflectType (Boolean _) = "Boolean"
-reflectType (Int _) = "Int"
-reflectType (String _) = "String"
+derive instance genericExprType :: Generic ExprType _
 
-class (Show a, Eq a) <= Expressible a where
-  toExprType :: a -> ExprType
-  reflectProxy :: Proxy a -> String
-  print :: a -> String
+instance showExprType :: Show ExprType where
+  show = genericShow
 
-instance exprBoolean :: Expressible Boolean where
-  toExprType = Boolean
-  reflectProxy _ = "Boolean"
-  print = show
+data Expr
+  = Val ExprType
+  | If Expr Expr Expr
+  | Equal Expr Expr
+  | Lookup Key
 
-instance exprInt :: Expressible Int where
-  toExprType = Int
-  reflectProxy _ = "Int"
-  print = show
+derive instance genericExpr :: Generic Expr _
 
-instance exprString :: Expressible String where
-  toExprType = String
-  reflectProxy _ = "String"
-  print = identity
+instance showExpr :: Show Expr where
+  show x = genericShow x
 
-instance exprVoid :: Expressible Void where
-  toExprType = absurd
-  reflectProxy _ = "Void"
-  print = show
+data EvalError
+  = MissingKey Key
+  | IfCondition ExprType
+  | EqualMismatch { left :: ExprType, right :: ExprType }
+  
+evalExpr :: (Key -> Maybe ExprType) -> Expr -> Either EvalError ExprType
+evalExpr get = case _ of
+  Val x -> pure x
+  If x' y z -> case evalExpr get x' of
+    Right (Boolean false) -> evalExpr get z
+    Right (Boolean true) -> evalExpr get y
+    Right x -> Left (IfCondition x)
+    Left x -> Left x
+  Equal x' y' -> case evalExpr get x', evalExpr get y' of
+    Right (Boolean x), Right (Boolean y) -> Right (Boolean $ x == y)
+    Right (Int x), Right (Int y) -> Right (Boolean $ x == y)
+    Right (String x), Right (String y) -> Right (Boolean $ x == y)
+    Right left, Right right -> Left (EqualMismatch { left, right })
+    Left x, _ -> Left x
+    _, Left x -> Left x
+  Lookup x -> maybe (Left $ MissingKey x) Right (get x)
 
-data ExprF i o
-  = Val (i ~ Void) o
-  | If (i ~ Boolean) (Expr Boolean) (Expr o) (Expr o)
-  | Equal (o ~ Boolean) (Expr i) (Expr i)
-  | Print (o ~ String) (Expr i)
+boolean_ :: Boolean -> Expr
+boolean_ = Val <<< Boolean
 
-data Expr o = Expr (∀ e. (∀ i. Expressible i => ExprF i o -> e) -> e)
+int_ :: Int -> Expr
+int_ = Val <<< Int
 
-data ExprA
-  = ValA ExprType
-  | IfA ExprA ExprA ExprA String String
-  | EqualA ExprA ExprA String String
-  | PrintA ExprA String String
+string_ :: String -> Expr
+string_ = Val <<< String
 
-mkExpr
-  :: ∀ i o
-   . Expressible i
-  => Expressible o
-  => ExprF i o
-  -> Expr o
-mkExpr e = Expr (_ $ e)
+if_ :: Expr -> Expr -> Expr -> Expr
+if_ = If
 
-val_ :: forall o. Expressible o => o -> Expr o
-val_ x = mkExpr (Val identity x)
+equal_ :: Expr -> Expr -> Expr
+equal_ = Equal
 
-if_
-  :: forall o
-   . Expressible o
-  => Expr Boolean
-  -> Expr o
-  -> Expr o
-  -> Expr o
-if_ x y z = mkExpr (If identity x y z)
-
-equal_
-  :: forall o
-   . Expressible o
-  => Expr o
-  -> Expr o
-  -> Expr Boolean
-equal_ x y = mkExpr (Equal identity x y)
-
-print_
-  :: forall o
-   . Expressible o
-  => Expr o
-  -> Expr String
-print_ x = mkExpr (Print identity x)
-
-runExpr
-  :: ∀ o e
-   . (∀ i. Expressible i => ExprF i o -> e)
-  -> Expr o
-  -> e
-runExpr r (Expr f) = f r
-
-evalExpr' :: ∀ o. Expressible o => Expr o -> o
-evalExpr' = runExpr eval
-  where
-  eval :: ∀ i. Expressible i => ExprF i o -> o
-  eval (Val _ x) = x
-  eval (If p x y z) = if evalExpr' x then evalExpr' y else evalExpr' z
-  eval (Equal p x y) = coerceSymm p $ evalExpr' x == evalExpr' y
-  eval (Print p x) = coerceSymm p $ print $ evalExpr' x
-
-toExprA :: ∀ o. Expressible o => Expr o -> ExprA
-toExprA = runExpr go
-  where
-  go :: ∀ i. Expressible i => ExprF i o -> ExprA
-  go (Val _ x) = ValA (toExprType x)
-  go (If _ x y z) = IfA (toExprA x) (toExprA y) (toExprA z)
-    (reflectProxy $ Proxy :: Proxy i)
-    (reflectProxy $ Proxy :: Proxy o)
-  go (Equal _ x y) = EqualA (toExprA x) (toExprA y)
-    (reflectProxy $ Proxy :: Proxy i)
-    (reflectProxy $ Proxy :: Proxy o)
-  go (Print _ x) = PrintA (toExprA x)
-    (reflectProxy $ Proxy :: Proxy i)
-    (reflectProxy $ Proxy :: Proxy o)
-
-instance showExpr :: Expressible o => Show (Expr o) where
-  show = runExpr go
-    where
-      go :: ∀ i. Expressible i => ExprF i o -> String
-      go (Val _ x) = "(Val _ " <> show x <> ")"
-      go (If _ x y z) = "(If _ " <> show x <> " " <> show y <> " " <> show z <> ")"
-      go (Equal _ x y) = "(Equal _ " <> show x <> " " <> show y <> ")"
-      go (Print _ x) = "(Print _ " <> show x <> ")"
-
-instance encodeExprType :: EncodeJson ExprType where
-  encodeJson (Boolean x) = encodeJson x
-  encodeJson (Int x) = encodeJson x
-  encodeJson (String x) = encodeJson x
-
-instance encodeExprA :: EncodeJson ExprA where
-  encodeJson (ValA x) =
-    "param" := x ~> encodeHelper "Val" "Void" (reflectType x)
-  encodeJson (IfA x y z i o) =
-    "params" := [ x, y, z ] ~> encodeHelper "If" i o
-  encodeJson (EqualA x y i o) =
-    "params" := [ x, y ] ~> encodeHelper "Equal" i o
-  encodeJson (PrintA x i o) =
-    "params" := [ x ] ~> encodeHelper "Print" i o
-
-instance encodeExprBoolean :: EncodeJson (Expr Boolean) where
-  encodeJson = encodeJson <<< toExprA
-else instance encodeExprInt :: EncodeJson (Expr Int) where
-  encodeJson = encodeJson <<< toExprA
-else instance encodeExprString :: EncodeJson (Expr String) where
-  encodeJson = encodeJson <<< toExprA
-
-encodeHelper :: String -> String -> String -> Json
-encodeHelper op i o =
-  "op" := op ~> "in" := i ~> "out" := o ~> jsonEmptyObject
-
-instance decodeExprBoolean :: DecodeJson (Expr Boolean) where
-  decodeJson json = do
-    x <- decodeJson json
-    x .: "in" >>= case _ of
-      "Boolean" -> do
-        e :: ExprF Boolean Boolean <- decodeJson json
-        pure $ mkExpr e
-      "Int" -> do
-        e :: ExprF Int Boolean <- decodeJson json
-        pure $ mkExpr e
-      "String" -> do
-        e :: ExprF String Boolean <- decodeJson json
-        pure $ mkExpr e
-      "Void" -> do
-        e :: ExprF Void Boolean <- decodeJson json
-        pure $ mkExpr e
-      other -> Left $ other <> " not implemented"
-else instance decodeExprInt :: DecodeJson (Expr Int) where
-  decodeJson json = do
-    x <- decodeJson json
-    x .: "in" >>= case _ of
-      "Boolean" -> do
-        e :: ExprF Boolean Int <- decodeJson json
-        pure $ mkExpr e
-      "Int" -> do
-        e :: ExprF Int Int <- decodeJson json
-        pure $ mkExpr e
-      "String" -> do
-        e :: ExprF String Int <- decodeJson json
-        pure $ mkExpr e
-      "Void" -> do
-        e :: ExprF Void Int <- decodeJson json
-        pure $ mkExpr e
-      other -> Left $ other <> " not implemented"
-else instance decodeExprString :: DecodeJson (Expr String) where
-  decodeJson json = do
-    x <- decodeJson json
-    x .: "in" >>= case _ of
-      "Boolean" -> do
-        e :: ExprF Boolean String <- decodeJson json
-        pure $ mkExpr e
-      "Int" -> do
-        e :: ExprF Int String <- decodeJson json
-        pure $ mkExpr e
-      "String" -> do
-        e :: ExprF String String <- decodeJson json
-        pure $ mkExpr e
-      "Void" -> do
-        e :: ExprF Void String <- decodeJson json
-        pure $ mkExpr e
-      other -> Left $ other <> " not implemented"
-
-instance decodeVal :: DecodeJson o => DecodeJson (ExprF Void o) where
-  decodeJson json = do
-    x <- decodeJson json
-    x .: "param" >>= pure <<< Val identity
-else instance decodeExprFBooleanBoolean :: DecodeJson (ExprF Boolean Boolean) where
-  decodeJson json = do
-    x <- decodeJson json
-    params <- x .: "params"
-    x .: "op" >>= case _ of
-      "If" -> decodeIfF params
-      "Equal" -> decodeEqualF params
-      op -> Left $ op <> " invald op"
-else instance decodeExprFIBoolean :: DecodeJson (Expr i) => DecodeJson (ExprF i Boolean) where
-  decodeJson json = do
-    x <- decodeJson json
-    params <- x .: "params"
-    x .: "op" >>= case _ of
-      "Equal" -> decodeEqualF params
-      op -> Left $ op <> " invalid op"
-else instance decodeExprFBooleanO :: DecodeJson (Expr o) => DecodeJson (ExprF Boolean o) where
-  decodeJson json = do
-    x <- decodeJson json
-    params <- x .: "params"
-    x .: "op" >>= case _ of
-      "If" -> decodeIfF params
-      op -> Left $ op <> " invalid op"
-else instance decodeExprFOther :: DecodeJson (ExprF i o) where
-  decodeJson _ = Left "Unimplemented"
-
-decodeIfF
-  :: ∀ o
-   . DecodeJson (Expr o)
-  => Array Json
-  -> Either String (ExprF Boolean o)
-decodeIfF [ x, y, z ] = do
-  x' :: Expr Boolean <- decodeJson x
-  y' :: Expr o <- decodeJson y
-  z' :: Expr o <- decodeJson z
-  pure $ If identity x' y' z'
-decodeIfF xs = Left "Expceted 3 params"
-
-decodeEqualF
-  :: ∀ i
-   . DecodeJson (Expr i)
-  => Array Json
-  -> Either String (ExprF i Boolean)
-decodeEqualF [ x, y ] = do
-  x' :: Expr i <- decodeJson x
-  y' :: Expr i <- decodeJson y
-  pure $ Equal identity x' y'
-decodeEqualF xs = Left "Expected 2 params"
+lookup_ :: Key -> Expr
+lookup_ = Lookup

--- a/src/Data/Form.purs
+++ b/src/Data/Form.purs
@@ -7,7 +7,7 @@ import Data.Either (Either(..))
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
 import Data.Maybe (Maybe(..))
-import Lynx.Data.Expr (Expr, ExprType(..), boolean_, if_, lookup_, string_)
+import Lynx.Data.Expr (Expr, boolean_, if_, lookup_, string_)
 import Type.Row (type (+))
 
 type LayoutRows c r =
@@ -171,6 +171,6 @@ active =
     }
   }
   where
-  description = if_ (lookup_ "active" $ Boolean true)
+  description = if_ (lookup_ "active" $ boolean_ true)
     (string_ "User's account is active!")
     (string_ "User's account is not active")

--- a/src/Data/Form.purs
+++ b/src/Data/Form.purs
@@ -7,7 +7,7 @@ import Data.Either (Either(..))
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
 import Data.Maybe (Maybe(..))
-import Lynx.Data.Expr (Expr, boolean_, equal_, if_, lookup_, string_)
+import Lynx.Data.Expr (Expr, boolean_, if_, lookup_, string_)
 import Type.Row (type (+))
 
 type LayoutRows c r =

--- a/src/Data/Form.purs
+++ b/src/Data/Form.purs
@@ -7,7 +7,7 @@ import Data.Either (Either(..))
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
 import Data.Maybe (Maybe(..))
-import Lynx.Data.Expr (Expr, boolean_, if_, lookup_, string_)
+import Lynx.Data.Expr (Expr, ExprType(..), boolean_, if_, lookup_, string_)
 import Type.Row (type (+))
 
 type LayoutRows c r =
@@ -171,6 +171,6 @@ active =
     }
   }
   where
-  description = if_ (lookup_ "active")
+  description = if_ (lookup_ "active" $ Boolean true)
     (string_ "User's account is active!")
     (string_ "User's account is not active")

--- a/src/Data/Form.purs
+++ b/src/Data/Form.purs
@@ -61,7 +61,7 @@ data Input f
   = Text (Record (SharedRows f + RequiredRows f + StringRows f ()))
   | Toggle (Record (SharedRows f ()))
 
-derive instance genericInput :: Generic (Input Expr) _
+derive instance genericInput :: Generic (Input f) _
 instance showInput :: Show (Input Expr) where show = genericShow
 
 instance encodeInput :: EncodeJson (Input Expr) where
@@ -69,7 +69,7 @@ instance encodeInput :: EncodeJson (Input Expr) where
     Text r -> "type" := "Text" ~> encodeJson r
     Toggle r -> "type" := "Toggle" ~> encodeJson r
 
-instance decodeJsonInput :: DecodeJson (Input Expr) where
+instance decodeInput :: DecodeJson (Input Expr) where
   decodeJson json = do
     x <- decodeJson json
     x .: "type" >>= case _ of
@@ -171,6 +171,6 @@ active =
     }
   }
   where
-  description = if_ (equal_ (boolean_ true) (lookup_ "active"))
+  description = if_ (lookup_ "active")
     (string_ "User's account is active!")
     (string_ "User's account is not active")

--- a/src/Data/Form.purs
+++ b/src/Data/Form.purs
@@ -2,42 +2,13 @@ module Lynx.Data.Form where
 
 import Prelude
 
-import Data.Argonaut (class DecodeJson, class EncodeJson, decodeJson, encodeJson, fromString, (.:), (:=), (~>))
+import Data.Argonaut (class DecodeJson, class EncodeJson, decodeJson, fromString)
 import Data.Either (Either(..))
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
 import Data.Maybe (Maybe(..))
-import Lynx.Data.Expr (Expr, val_)
+import Lynx.Data.Expr (Expr, boolean_, equal_, if_, lookup_, string_)
 import Type.Row (type (+))
-
--- newtype EvalExpr = EvalExpr
-  -- { lookups :: Object (Array String)
-  -- }
-
--- instance evalMaybeExpr
-  -- :: Expressible o
-  -- => Mapping EvalExpr (Maybe (Expr o)) (Maybe (Identity o))
-  -- where
-  -- mapping f = map $ mapping f
--- else instance evalArr
-  -- :: HMap EvalExpr (n Expr) (n Identity)
-  -- => Mapping EvalExpr (Array (n Expr)) (Array (n Identity))
-  -- where
-  -- mapping f = map $ hmap f
--- else instance evalExpr
-  -- :: Expressible o
-  -- => Mapping EvalExpr (Expr o) (Identity o)
-  -- where
-  -- mapping (EvalExpr f) = do
-    -- pure <<< evalExpr'
--- else instance evalInput
-  -- :: Mapping EvalExpr (Input Expr) (Input Identity)
-  -- where
-  -- mapping f = hmap f
--- else instance evalVal
-  -- :: Mapping EvalExpr a a
-  -- where
-  -- mapping f = identity
 
 type LayoutRows c r =
   ( name :: String
@@ -45,89 +16,38 @@ type LayoutRows c r =
   | r
   )
 
--- newtype Page f = Page (Record (LayoutRows (Section f) ()))
-
 type Page f = Record (LayoutRows (Section f) ())
 
--- derive instance newtypePage :: Newtype (Page f) _
--- derive instance genericPage :: Generic (Page f) _
--- instance showPage :: Show (Page Expr) where show = genericShow
-
--- instance encodePage :: EncodeJson (Page Expr) where
-  -- encodeJson = encodeJson <<< unwrap
-
--- instance decodePage :: DecodeJson (Page Expr) where
-  -- decodeJson = pure <<< wrap <=< decodeJson
-
--- instance hmapPage
-  -- :: HMap EvalExpr (Page Expr) (Page Identity)
-  -- where
-  -- hmap f = over Page $ hmap f
-
--- newtype Section f = Section (Record (LayoutRows (Field f) ()))
-
 type Section f = Record (LayoutRows (Field f) ())
-
--- derive instance newtypeSection :: Newtype (Section f) _
--- derive instance genericSection :: Generic (Section f) _
--- instance showSection :: Show (Section Expr) where show = genericShow
-
--- instance encodeSection :: EncodeJson (Section Expr) where
-  -- encodeJson = encodeJson <<< unwrap
-
--- instance decodeSection :: DecodeJson (Section Expr) where
-  -- decodeJson = pure <<< wrap <=< decodeJson
-
--- instance hmapSection
-  -- :: HMap EvalExpr (Section Expr) (Section Identity)
-  -- where
-  -- hmap f = over Section $ hmap f
 
 type Key = String
 
 type FieldRows f r =
-  ( name :: f String
-  , visibility :: f Boolean
-  , description :: f String
+  ( name :: f
+  , visibility :: f
+  , description :: f
   , key :: Key
   , input :: Input f
   | r
   )
 
--- newtype Field f = Field (Record (FieldRows f ()))
-
 type Field f = Record (FieldRows f ())
 
--- derive instance newtypeField :: Newtype (Field f) _
--- derive instance genericField :: Generic (Field f) _
--- instance showField :: Show (Field Expr) where show = genericShow
-
--- instance encodeField :: EncodeJson (Field Expr) where
-  -- encodeJson = encodeJson <<< unwrap
-
--- instance decodeField :: DecodeJson (Field Expr) where
-  -- decodeJson = pure <<< wrap <=< decodeJson
-
--- instance hmapField
-  -- :: HMap EvalExpr (Field Expr) (Field Identity)
-  -- where
-  -- hmap f = over Field $ hmap f
-
-type SharedRows f t r =
-  ( default :: Maybe (f t)
-  , value :: Record (InputState t ())
+type SharedRows f r =
+  ( default :: Maybe f
+  , value :: Record (InputState f ())
   | r
   )
 
 type RequiredRows f r =
-  ( required :: f Boolean
+  ( required :: f
   | r
   )
 
 type StringRows f r =
-  ( placeholder :: f String
-  , maxLength :: Maybe (f Int)
-  , minLength :: Maybe (f Int)
+  ( placeholder :: f
+  , maxLength :: Maybe f
+  , minLength :: Maybe f
   | r
   )
 
@@ -138,29 +58,11 @@ type InputState t r =
   )
 
 data Input f
-  = Text (Record (SharedRows f String + RequiredRows f + StringRows f ()))
-  | Toggle (Record (SharedRows f Boolean ()))
+  = Text (Record (SharedRows f + RequiredRows f + StringRows f ()))
+  | Toggle (Record (SharedRows f ()))
 
-derive instance genericInput :: Generic (Input f) _
+derive instance genericInput :: Generic (Input Expr) _
 instance showInput :: Show (Input Expr) where show = genericShow
--- instance hmapInput
-  -- :: HMap EvalExpr (Input Expr) (Input Identity)
-  -- where
-  -- hmap f (Text r) = Text $ hmap f r
-  -- hmap f (Toggle r) = Toggle $ hmap f r
-
-instance encodeInput :: EncodeJson (Input Expr) where
-  encodeJson = case _ of
-    Text r -> "type" := "Text" ~> encodeJson r
-    Toggle r -> "type" := "Toggle" ~> encodeJson r
-
-instance decodeInput :: DecodeJson (Input Expr) where
-  decodeJson json = do
-    x <- decodeJson json
-    x .: "type" >>= case _ of
-      "Text" -> pure <<< Text <=< decodeJson $ json
-      "Toggle" -> pure <<< Toggle <=< decodeJson $ json
-      t -> Left $ "Unsupported Input type: " <> t
 
 data InputSource
   = UserInput
@@ -205,16 +107,16 @@ testSection =
 
 firstName :: Field Expr
 firstName =
-  { name: val_ "First Name"
-  , visibility: val_ true
-  , description: val_ "Enter your first name"
+  { name: string_ "First Name"
+  , visibility: boolean_ true
+  , description: string_ "Enter your first name"
   , key: "firstName"
   , input: Text
     { default: Nothing
     , maxLength: Nothing
     , minLength: Nothing
-    , placeholder: val_ ""
-    , required: val_ true
+    , placeholder: string_ ""
+    , required: boolean_ true
     , value:
       { source: Nothing
       , value: Nothing
@@ -224,16 +126,16 @@ firstName =
 
 lastName :: Field Expr
 lastName =
-  { name: val_ "Last Name"
-  , visibility: val_ true
-  , description: val_ "Enter your last name"
+  { name: string_ "Last Name"
+  , visibility: boolean_ true
+  , description: string_ "Enter your last name"
   , key: "lastName"
   , input: Text
     { default: Nothing
     , maxLength: Nothing
     , minLength: Nothing
-    , placeholder: val_ ""
-    , required: val_ true
+    , placeholder: string_ ""
+    , required: boolean_ true
     , value:
       { source: Nothing
       , value: Nothing
@@ -243,15 +145,19 @@ lastName =
 
 active :: Field Expr
 active =
-  { name: val_ "Active"
-  , visibility: val_ true
-  , description: val_ "Is user's account active"
+  { name: string_ "Active"
+  , visibility: boolean_ true
+  , description
   , key: "active"
   , input: Toggle
-    { default: Just (val_ false)
+    { default: Just (boolean_ true)
     , value:
       { source: Nothing
       , value: Nothing
       }
     }
   }
+  where
+  description = if_ (equal_ (boolean_ true) (lookup_ "active"))
+    (string_ "User's account is active!")
+    (string_ "User's account is not active")

--- a/src/Page/Form.purs
+++ b/src/Page/Form.purs
@@ -166,8 +166,6 @@ component =
 
   renderEvalError :: forall a. EvalError -> H.ComponentHTML a
   renderEvalError = case _ of
-    MissingKey x ->
-      HH.text $ "Could not find input with key: " <> show x
     IfCondition x ->
       HH.text $
         "Expected conditional to be a Boolean, but its type is: "

--- a/src/Page/Form.purs
+++ b/src/Page/Form.purs
@@ -4,12 +4,17 @@ import Prelude
 
 import Data.Bitraversable (bitraverse_)
 import Data.Either (Either(..))
+import Data.Foldable (foldMap)
+import Data.Map (Map)
+import Data.Map as Data.Map
 import Data.Maybe (Maybe(..))
+import Data.Traversable (traverse)
 import Halogen as H
 import Halogen.HTML as HH
+import Halogen.HTML.Events as HE
 import Halogen.HTML.Properties as HP
-import Lynx.Data.Expr (Expr)
-import Lynx.Data.Form (Field, Input(..), Page, Section, testPage)
+import Lynx.Data.Expr (EvalError, Expr(..), ExprType(..), Key, evalExpr)
+import Lynx.Data.Form (Field, Input(..), InputSource(..), InputState, Page, Section, testPage)
 import Ocelot.Block.Card as Card
 import Ocelot.Block.FormField as FormField
 import Ocelot.Block.Format as Format
@@ -19,12 +24,14 @@ import Ocelot.Block.Toggle (toggle) as Toggle
 import Ocelot.HTML.Properties (css)
 
 type State =
-  { form :: Either String (Page Expr)
+  { form :: Either String { expr :: Page Expr, evaled :: Page ExprType }
+  , values :: Map Key ExprType
   }
 
 data Query a
   = Initialize a
   | EvalForm (Page Expr) a
+  | UpdateKey Key ExprType a
 
 type ParentInput = String
 
@@ -47,18 +54,105 @@ component =
   initialState :: State
   initialState =
     { form: Left "Loading..."
+    , values: mempty
     }
 
   eval :: Query ~> H.ComponentDSL State Query Message m
   eval (Initialize a) = a <$ do
+    let values = keysPage testPage
+    H.modify_ _ { values = values }
     void $ bitraverse_
       (\e -> H.modify _ { form = Left e })
       (\f -> eval $ EvalForm f a)
       (Right testPage)
 
-  eval (EvalForm form a) = a <$ do
-    H.modify_ _ { form = pure form }
-    pure unit
+  eval (EvalForm expr a) = a <$ do
+    let evaled' = evalPage get expr
+        get key = Data.Map.lookup key values
+        values = keysPage expr
+    H.modify_ _ { values = values }
+    case evaled' of
+      Left _ -> pure unit
+      Right evaled -> H.modify_ _ { form = pure { expr, evaled } }
+
+  eval (UpdateKey key val a) = do
+    form <- H.gets _.form
+    case form of
+      Left _ -> pure a
+      Right { expr: expr' } -> do
+        H.modify_ \state ->
+          state { values = Data.Map.insert key val state.values }
+        let expr = setPage key val expr'
+        eval (EvalForm expr a)
+
+  evalPage :: (Key -> Maybe ExprType) -> Page Expr -> Either EvalError (Page ExprType)
+  evalPage get page = do
+    contents <- traverse (evalSection get) page.contents
+    pure page { contents = contents }
+
+  evalSection :: (Key -> Maybe ExprType) -> Section Expr -> Either EvalError (Section ExprType)
+  evalSection get section = do
+    contents <- traverse (evalField get) section.contents
+    pure section { contents = contents }
+
+  evalField :: (Key -> Maybe ExprType) -> Field Expr -> Either EvalError (Field ExprType)
+  evalField get field = do
+    description <- evalExpr get field.description
+    input <- evalInput get field.input
+    name <- evalExpr get field.name
+    visibility <- evalExpr get field.visibility
+    pure { description, key: field.key, input, name, visibility }
+
+  evalInput :: (Key -> Maybe ExprType) -> Input Expr -> Either EvalError (Input ExprType)
+  evalInput get = case _ of
+    Text input -> do
+      default <- traverse (evalExpr get) input.default
+      maxLength <- traverse (evalExpr get) input.maxLength
+      minLength <- traverse (evalExpr get) input.minLength
+      placeholder <- evalExpr get input.placeholder
+      required <- evalExpr get input.required
+      value <- evalInputState get input.value
+      pure
+        ( Text
+          { default
+          , maxLength
+          , minLength
+          , placeholder
+          , required
+          , value
+          }
+        )
+    Toggle input -> do
+      default <- traverse (evalExpr get) input.default
+      value <- evalInputState get input.value
+      pure (Toggle { default, value })
+
+  evalInputState :: (Key -> Maybe ExprType) -> Record (InputState Expr ()) -> Either EvalError (Record (InputState ExprType ()))
+  evalInputState get inputState = do
+    value <- traverse (evalExpr get) inputState.value
+    pure inputState { value = value }
+
+  keysPage :: Page Expr -> Map Key ExprType
+  keysPage page = foldMap keysSection page.contents
+
+  keysSection :: Section Expr -> Map Key ExprType
+  keysSection section = foldMap keysField section.contents
+
+  keysField :: Field Expr -> Map Key ExprType
+  keysField field = case field.input of
+    Text { value: { value: Just expr } }
+      | Right value <- evalExpr (const Nothing) expr ->
+        Data.Map.singleton field.key value
+    Text { default: Just expr }
+      | Right value <- evalExpr (const Nothing) expr ->
+        Data.Map.singleton field.key value
+    Toggle { value: { value: Just expr } }
+      | Right value <- evalExpr (const Nothing) expr ->
+        Data.Map.singleton field.key value
+    Toggle { default: Just expr }
+      | Right value <- evalExpr (const Nothing) expr ->
+        Data.Map.singleton field.key value
+    _ -> mempty
 
   render :: State -> H.ComponentHTML Query
   render { form } =
@@ -69,18 +163,18 @@ component =
         Right page ->
           append
           [ Format.heading_
-            [ HH.text page.name ]
+            [ HH.text page.evaled.name ]
           ]
-          $ renderSection <$> page.contents
+          $ renderSection <$> page.evaled.contents
 
-  renderSection :: Section Expr -> H.ComponentHTML Query
+  renderSection :: Section ExprType -> H.ComponentHTML Query
   renderSection (section) =
     Card.card_ $
       append
       [ Format.subHeading_ [ HH.text section.name ] ]
       $ renderField <$> section.contents
 
-  renderField :: Field Expr -> H.ComponentHTML Query
+  renderField :: Field ExprType -> H.ComponentHTML Query
   renderField (field) =
     FormField.field_
       { label: HH.text $ show field.name
@@ -90,7 +184,7 @@ component =
       }
       [ renderInput field ]
 
-  renderInput :: Field Expr -> H.ComponentHTML Query
+  renderInput :: Field ExprType -> H.ComponentHTML Query
   renderInput (field) = case field.input of
     Text input ->
       Input.input
@@ -101,4 +195,24 @@ component =
       Toggle.toggle
         [ HP.checked true
         , HP.id_ field.key
+        , HE.onChecked (HE.input $ UpdateKey field.key <<< Boolean)
         ]
+
+  setPage :: Key -> ExprType -> Page Expr -> Page Expr
+  setPage key val page =
+    page { contents = map (setSection key val) page.contents}
+
+  setSection :: Key -> ExprType -> Section Expr -> Section Expr
+  setSection key val section =
+    section { contents = map (setField key val) section.contents}
+
+  setField :: Key -> ExprType -> Field Expr -> Field Expr
+  setField key val field
+    | key == field.key = case field.input of
+      Text input ->
+        let value = { source: Just UserInput,  value: Just (Val val) }
+        in field { input = Text input { value = value }}
+      Toggle input ->
+        let value = { source: Just UserInput,  value: Just (Val val) }
+        in field { input = Toggle input { value = value }}
+    | otherwise = field

--- a/test/Test/Data/Expr.purs
+++ b/test/Test/Data/Expr.purs
@@ -37,7 +37,7 @@ testFalseJson = """
   { "op": "Val", "param": false, "in": "Void", "out": "Boolean" }
 """
 
-test1Either :: Either String (Expr Int)
+test1Either :: Either String Expr
 test1Either = decodeJson =<< jsonParser test1Json
 
 testAJson :: String
@@ -52,7 +52,7 @@ testAJson = """
   }
 """
 
-testAEither :: Either String (Expr Boolean)
+testAEither :: Either String Expr
 testAEither = decodeJson =<< jsonParser testAJson
 
 testBJson :: String
@@ -68,5 +68,5 @@ testBJson = """
   }
 """
 
-testBEither :: Either String (Expr Int)
+testBEither :: Either String Expr
 testBEither = decodeJson =<< jsonParser testBJson


### PR DESCRIPTION
##### What it does

Tries an approach to encoding expressions as untyped. The motivation behind this change is that the well-typed expressions were giving us issues when attempting to evaluate them. If we have no real types, we can always attempt to evaluate something. It ends up that we have to deal with failure in the cases where we've constructed an ill-typed expression, though.

##### Review asks

Is this approach something we want to continue pursuing? I'm more than happy to close this PR in exchange for something else, but I'm not sure what that something else might be.

There are a few open questions that I couldn't figure out on my own. I left them as review notes in this PR.