### PR TITLE
Switch over to a `Makefile`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,16 +24,8 @@ jobs:
             - v0.1-purs-cache
 
       - run:
-          name: Install Node and Bower dependencies
-          command: npm i && npx bower i
-
-      - run:
-          name: Verify the project builds successfully
-          command: npm run build
-
-      - run:
-          name: Verify the tests run successfully
-          command: npm run test
+          name: Verify the project builds and tests run successfully
+          command: make test
 
       - save_cache:
           key: v0.1-npm-cache-{{ .Branch }}-{{ checksum "package.json" }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.build/
 /bower_components/
 /node_modules/
 /.pulp-cache/

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,23 @@
 # we can clean up builds really easily: delete this directory.
 #
 # We use some make syntax that might be unfamiliar, a quick refresher:
+# make is based on a set of rules
 #
-# <target>: <prerequisites> | <order-only-prerequisites>
-# 	<command>
+# <targets>: <prerequisites> | <order-only-prerequisites>
+# 	<recipe>
+#
+# `<targets>` are the things we want to make. This is usually a single file,
+# but it can be multiple things separated by spaces.
+#
+# `<prerequisites>` are the things that decide when `<targets>` is out of date.
+# These are also usually files. They are separated by spaces.
+# If any of the `<prerequisites>` are newer than the `<targets>`,
+# the recipe is run to bring the `<targets>` up to date.
+#
+# `<recipe>` are the commands to run to brin the `<targets>` up to date.
+# These are commands like we write on a terminal.
+#
+# See: https://www.gnu.org/software/make/manual/make.html#Rule-Syntax
 #
 # `<order-only-prerequisites>` are similar to normal `<prerequisites>`
 # but they don't cause a target to be rebuilt if they're out of date.
@@ -28,6 +42,20 @@
 # $< - Expands to the first prerequisite of the recipe.
 #
 # See: https://www.gnu.org/software/make/manual/make.html#Automatic-Variables
+#
+# `.DEFAULT_GOAL` is the goal to use if no other goals are specified.
+# Normally, the first goal in the file is used if no other goals are specified.
+# Setting this allows us to override that behavior.
+#
+# See: https://www.gnu.org/software/make/manual/make.html#index-_002eDEFAULT_005fGOAL-_0028define-default-goal_0029
+#
+# `.PHONY` forces a recipe to always run. This is useful for things that are
+# more like commands than targets. For instance, we might want to clean up
+# all artifacts. Since there's no useful target, we can mark `clean` with
+# `.PHONY` and make will run the task every time we ask it to.
+#
+# See: https://www.gnu.org/software/make/manual/make.html#Phony-Targets
+# See: https://www.gnu.org/software/make/manual/make.html#index-_002ePHONY-1
 
 BOWER_COMPONENTS := bower_components/.stamp
 BUILD := .build

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,8 @@ BUILD := .build
 NODE_MODULES := node_modules/.stamp
 OUTPUT := output
 PSA_ARGS := --censor-lib --stash=$(BUILD)/.psa_stash --strict
-SRCS := $(shell find src -name '*.purs' -type f)
+SRC := src
+SRCS := $(shell find $(SRC) -name '*.purs' -type f)
 TESTS := $(shell find test -name '*.purs' -type f)
 
 .DEFAULT_GOAL := dist/main.js
@@ -73,4 +74,4 @@ test: dist/main.js $(BUILD)/test.out
 
 .PHONY: watch
 watch: $(BOWER_COMPONENTS) $(NODE_MODULES)
-	npx pulp --watch build --to dist/main.js
+	npx watch-exec --command 'npx pulp build --to dist/main.js' --watch $(SRC)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# purescript-lynx
+
+## Developing
+
+We use make to take care of building everything for us.
+You should be able to run `make` and have everything installed and built.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "bower": "^1.8.8",
     "pulp": "^12.3.1",
     "purescript": "^0.12.2",
-    "purescript-psa": "^0.7.3"
+    "purescript-psa": "^0.7.3",
+    "watch-exec": "^1.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,9 +1,8 @@
 {
   "name": "purescript-formal",
   "scripts": {
-    "build": "npm run compile && pulp build --to dist/main.js",
-    "compile": "pulp build -- --censor-lib --stash --strict",
-    "test": "pulp test"
+    "build": "make",
+    "test": "make test"
   },
   "license": "ISC",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,5 @@
 {
   "name": "purescript-formal",
-  "scripts": {
-    "build": "make",
-    "test": "make test"
-  },
   "license": "ISC",
   "devDependencies": {
     "bower": "^1.8.8",


### PR DESCRIPTION
##### What it does

As discussed on slack, we're going to try using a `Makefile` for building PS stuff. This is mostly a direct port of the npm scripts. It does set up dependencies automatically though. I didn't want to spend too much time on this, so it's still pretty naïve. It could be made a bit better by using `purs` directly instead of going through `pulp` still.

More than happy to explain more motivation if it's not clear from the commit/slack conversation.

##### Review asks

Are we cool with moving to a `Makefile`?

Requesting a review from Dave (since you're working a bunch in this repo) and Forest (since we're in this escapade together).