### PR TITLE
Start using nix

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,22 @@
+set -euo pipefail
+
+use_nix() {
+    local cache=.direnv.cache
+    if [[ ! -e "${cache}" || \
+              "${HOME}/.direnvrc" -nt "${cache}" || \
+              .envrc -nt "${cache}" || \
+              default.nix -nt "${cache}" \
+        ]]; then
+        local tmp="$(mktemp "${cache}.tmp-XXXXXXXX")"
+        trap "rm -rf ${tmp}" EXIT
+
+        nix-shell --show-trace "$@" --run 'direnv dump' > "${tmp}"
+        mv "${tmp}" "${cache}"
+    fi
+
+    if direnv_load cat "${cache}"; then
+        watch_file default.nix
+    fi
+}
+
+use_nix

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /.psc*
 /.purs*
 /.psa*
+/.direnv.cache

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,35 @@
+let
+
+  buildInputs = [
+    nixpkgs.coreutils
+    nixpkgs.findutils
+    nixpkgs.git
+    nixpkgs.gnumake
+    nixpkgs.nodejs-10_x
+    nixpkgs.yarn
+  ];
+
+  nixpkgs = import nixpkgs-tarball {};
+
+  nixpkgs-tarball = builtins.fetchTarball {
+    inherit sha256;
+    url = "https://github.com/NixOS/nixpkgs/archive/${revision}.tar.gz";
+  };
+
+  revision = "7f35ed9df40f12a79a242e6ea79b8a472cf74d42";
+
+  sha256 = "sha256:1wr6dzy99rfx8s399zjjjcffppsbarxl2960wgb0xjzr7v65pikz";
+
+in
+
+  nixpkgs.stdenv.mkDerivation rec {
+    inherit buildInputs;
+
+    env = nixpkgs.buildEnv {
+      inherit name;
+
+      paths = buildInputs;
+    };
+
+    name = "purescript-lynx";
+  }


### PR DESCRIPTION
## What it does

While helping Gabe get setup, we were running into version issues with different things. When we got to this repo, we ran into a version issue with `make`. Since we'd been hitting version differences throughout other projects, we tried to fix this going forward for this repo. We use `nix` specify the dependencies of all the programs we need in this repo. Ideally this should mean that anyone that comes to the project will always have the correct versions of everything.

The motivation behind `nix` is that there are some programs we need available in development. This doesn't negate the need/use of `docker` or `k8s`.

## Review asks

* Are we okay with adding `nix` to the repo? Dave and I have talked about it in the past and we're both onboard. Gabe is also onboard. Any thing to be concerned about?

## TODO

* [ ] Document `nix`
    * [ ] Installation
    * [ ] Motivation
* [ ] Document `direnv`
    * [ ] Installation
    * [ ] Motivation