### PR TITLE
Add a `make test-watch` task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,4 +149,4 @@ watch: $(BOWER_COMPONENTS) $(NODE_MODULES)
 
 .PHONY: test-watch
 test-watch: $(BOWER_COMPONENTS) $(NODE_MODULES)
-	npx watch-exec --command 'make test' --watch $(TESTS) --watch $(SRC)
+	npx watch-exec --command 'make test' --watch $(TEST) --watch $(SRC)

--- a/Makefile
+++ b/Makefile
@@ -146,3 +146,7 @@ test: dist/main.js $(BUILD)/test.out
 .PHONY: watch
 watch: $(BOWER_COMPONENTS) $(NODE_MODULES)
 	npx watch-exec --command 'make dist/main.js' --watch $(EXAMPLE) --watch $(SRC)
+
+.PHONY: test-watch
+test-watch: $(BOWER_COMPONENTS) $(NODE_MODULES)
+	npx watch-exec --command 'make test' --watch $(TESTS) --watch $(SRC)


### PR DESCRIPTION
## What it does

This adds a `make` task to watch `src/` and `test/` files and run `make test` after any changes.

## Review asks

It's not very efficient. I haven't looked closely, but I noticed that `make test` runs `psa` twice.
